### PR TITLE
Add ssm roles to README

### DIFF
--- a/ssm-automation/README.md
+++ b/ssm-automation/README.md
@@ -3,7 +3,9 @@
 This repository contains example SSM Automation Documents that can be used by SSM [Change Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/change-manager.html) feature to create PAAs and PAIs using multi-party authorization.
 
 ## IAM Roles
-This process will require the creation of IAM Roles to approve the Change Manager Templates, Approve the Change Manager Requests, and execute the automation documents. Before beginning, please make sure that you have all of the following IAM roles.
+This process will require the creation of IAM Roles to approve the Change Manager Templates and Requests, and execute the automation documents. Before beginning, please make sure that you have all of the roles listed below.
+
+The creation of the roles can be automated by running `./createRoles.sh`. Make sure to set your AWS account ID and the number of approver roles you want to create in the script before running it. 
 
 ### CreatePAA and CreatePAI Roles
 These roles will be used to execute the automation documents which create the PAAs and PAIs.
@@ -70,7 +72,7 @@ Policy for CreatePAI:
                 "acm-pca:GetCertificate",
                 "acm-pca:IssueCertificate"
             ],
-            "Resource": "<PAA_ARN>"
+            "Resource": "*"
         }
     ]
 }
@@ -138,6 +140,16 @@ Approval Policy:
 }
 ```
 
+### SSM Service Linked Role
+If you get the following error message while executing your Change Manager request
+
+`Failed to schedule runbook after step approved. Invalid permissions: Couldn't assume/create SSM SLR, check permissions for the calling identity.`
+
+Run the following command to create the missing SLR:
+
+`aws iam create-service-linked-role --aws-service-name ssm.amazonaws.com`
+
+## Creating a PAI/PAA with Change Manager
 To create a PAA or PAI with multiple approvers follow these steps:
 1. Go to the [Documents](https://console.aws.amazon.com/systems-manager/documents) section in AWS Systems Manager.
 2. Begin creating a new Automation Document.
@@ -146,11 +158,11 @@ To create a PAA or PAI with multiple approvers follow these steps:
 5. Begin creating a new Template.
 6. For the Runbook option, choose the Automation Document you created.
 7. Choose the desired approvers and fill in the rest of the fields.
-8. Submit the Template for review. **Note:** Make sure that you have the Template Approver Role (described in the "Template Approver Role" section above) registered in the "Settings" tab of Change Manager under "Template Reviewer".
+8. Submit the Template for review. **Note:** Make sure that you have the [Template Approver Role](#template-approver-role) registered in the "Settings" tab of Change Manager under "Template Reviewer".
 9. Approve the Template using the Template Approver Role.
 10. Start creating a new Request in Change Manager.
 11. Choose the Template you just created.
 12. Fill in all of the necessary fields.
 13. Provide the parameters with which the Automation Document will run while creating your PAA/PAI.
-14. Select the CreatePAA or CreatePAI role (described in the "CreatePAA and CreatePAI Roles" section above) for the "Automation assume role" section.
-15. Make sure all required approvers (with the permissions described in the "Request Approver Role" section above) approve the Request.
+14. Select the [CreatePAA or CreatePAI role](#createpaa-and-createpai-roles) for the "Automation assume role" section.
+15. Make sure all required approvers (with the permissions described in [Request Approver Role](#request-approver-role)) approve the Request.

--- a/ssm-automation/README.md
+++ b/ssm-automation/README.md
@@ -6,7 +6,7 @@ This repository contains example SSM Automation Documents that can be used by SS
 This process will require the creation of IAM Roles to approve the Change Manager Templates, Approve the Change Manager Requests, and execute the automation documents. Before beginning, please make sure that you have all of the following IAM roles.
 
 ### CreatePAA and CreatePAI Roles
-These roles will be used to execute the automation document which create the PAAs and PAIs.
+These roles will be used to execute the automation documents which create the PAAs and PAIs.
 
 Trust Relationship:
 ```json

--- a/ssm-automation/README.md
+++ b/ssm-automation/README.md
@@ -2,7 +2,11 @@
 
 This repository contains example SSM Automation Documents that can be used by SSM [Change Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/change-manager.html) feature to create PAAs and PAIs using multi-party authorization.
 
-**Note:** This process will require IAM Roles with permissions to access AWS Private CA. Before beginning, please make sure that you have an IAM role with the following trust relationship and permissions:
+## IAM Roles
+This process will require the creation of IAM Roles to approve the Change Manager Templates, Approve the Change Manager Requests, and execute the automation documents. Before beginning, please make sure that you have all of the following IAM roles.
+
+### CreatePAA and CreatePAI Roles
+These roles will be used to execute the automation document which create the PAAs and PAIs.
 
 Trust Relationship:
 ```json
@@ -23,7 +27,7 @@ Trust Relationship:
 }
 ```
 
-For CreatePAA:
+Policy for CreatePAA:
 ```json
 {
     "Version": "2012-10-17",
@@ -44,7 +48,7 @@ For CreatePAA:
 }
 ```
 
-For CreatePAI:
+Policy for CreatePAI:
 ```json
 {
     "Version": "2012-10-17",
@@ -72,6 +76,68 @@ For CreatePAI:
 }
 ```
 
+### Request Approver Role
+It is required that the roles which you want to approve the Change Manager Requests have the following permissions:
+
+Trust Relationship:
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::<AccountID>:root"
+            },
+            "Action": "sts:AssumeRole",
+            "Condition": {}
+        }
+    ]
+}
+```
+
+Managed Policies:
+1. [AmazonSSMAutomationApproverAccess](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonSSMAutomationApproverAccess.html)
+2. [AmazonSSMReadOnlyAccess](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonSSMReadOnlyAccess.html)
+
+### Template Approver Role
+It is required that the role you want to use to approve the Change Manager Templates has the following permissions:
+
+Trust Relationship:
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::<AccountID>:root"
+            },
+            "Action": "sts:AssumeRole",
+            "Condition": {}
+        }
+    ]
+}
+```
+
+Managed Policy:
+1. [AmazonSSMReadOnlyAccess](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonSSMReadOnlyAccess.html)
+
+Approval Policy:
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": "ssm:UpdateDocumentMetadata",
+            "Resource": "*"
+        }
+    ]
+}
+```
+
 To create a PAA or PAI with multiple approvers follow these steps:
 1. Go to the [Documents](https://console.aws.amazon.com/systems-manager/documents) section in AWS Systems Manager.
 2. Begin creating a new Automation Document.
@@ -80,10 +146,11 @@ To create a PAA or PAI with multiple approvers follow these steps:
 5. Begin creating a new Template.
 6. For the Runbook option, choose the Automation Document you created.
 7. Choose the desired approvers and fill in the rest of the fields.
-8. Submit the Template for review. **Note:** Make sure that you have a "Template Reviewer" registered in the "Settings" tab of Change Manager.
-9. Approve the Template.
+8. Submit the Template for review. **Note:** Make sure that you have the Template Approver Role (described in the "Template Approver Role" section above) registered in the "Settings" tab of Change Manager under "Template Reviewer".
+9. Approve the Template using the Template Approver Role.
 10. Start creating a new Request in Change Manager.
 11. Choose the Template you just created.
 12. Fill in all of the necessary fields.
 13. Provide the parameters with which the Automation Document will run while creating your PAA/PAI.
-14. Make sure all required approvers approve the Request.
+14. Select the CreatePAA or CreatePAI role (described in the "CreatePAA and CreatePAI Roles" section above) for the "Automation assume role" section.
+15. Make sure all required approvers (with the permissions described in the "Request Approver Role" section above) approve the Request.

--- a/ssm-automation/README.md
+++ b/ssm-automation/README.md
@@ -5,7 +5,9 @@ This repository contains example SSM Automation Documents that can be used by SS
 ## IAM Roles
 This process will require the creation of IAM Roles to approve the Change Manager Templates and Requests, and execute the automation documents. Before beginning, please make sure that you have all of the roles listed below.
 
-The creation of the roles can be automated by running `./createRoles.sh`. Make sure to set your AWS account ID and the number of approver roles you want to create in the script before running it. 
+The creation of the roles can be automated by running `./createRoles.sh`. Make sure to set up your [AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) with the CLI before running the script. You can specify how many request approver roles you want to be created by passing an argument to the script as follows (default is 2 roles):
+
+`./createRoles.sh <NUMBER_OF_ROLES>`
 
 ### CreatePAA and CreatePAI Roles
 These roles will be used to execute the automation documents which create the PAAs and PAIs.

--- a/ssm-automation/createRoles.sh
+++ b/ssm-automation/createRoles.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Replace with your AWS account ID
+AWS_ACCOUNT="1234567890"
+
+# Replace with the number of approver roles you want to create
+NUMBER_OF_REQUEST_APPROVERS=2
+
+echo "Creating CreatePAARole..."
+aws iam create-role --role-name CreatePAARole --assume-role-policy-document file://policies/SSMTrustPolicy.json
+PAA_POLICY_ARN=$(aws iam create-policy --policy-name CreatePAAPolicy --policy-document file://policies/CreatePAAPolicy.json | jq -r '.Policy.Arn')
+aws iam attach-role-policy --role-name CreatePAARole --policy-arn $PAA_POLICY_ARN
+
+echo "Creating CreatePAIRole..."
+aws iam create-role --role-name CreatePAIRole --assume-role-policy-document file://policies/SSMTrustPolicy.json
+PAI_POLICY_ARN=$(aws iam create-policy --policy-name CreatePAIPolicy --policy-document file://policies/CreatePAIPolicy.json | jq -r '.Policy.Arn')
+aws iam attach-role-policy --role-name CreatePAIRole --policy-arn $PAI_POLICY_ARN
+
+sed "s/<AccountID>/$AWS_ACCOUNT/g" policies/AccountTrustPolicy.json > policies/MyAccountTrustPolicy.json
+
+for i in $(seq $NUMBER_OF_REQUEST_APPROVERS)
+do
+    REQUEST_APPROVER_ROLE_NAME="ChangeManagerRequestApproverRole$i"
+    echo "Creating $REQUEST_APPROVER_ROLE_NAME..."
+    aws iam create-role --role-name $REQUEST_APPROVER_ROLE_NAME --assume-role-policy-document file://policies/MyAccountTrustPolicy.json
+    aws iam attach-role-policy --role-name $REQUEST_APPROVER_ROLE_NAME --policy-arn arn:aws:iam::aws:policy/AmazonSSMAutomationApproverAccess
+    aws iam attach-role-policy --role-name $REQUEST_APPROVER_ROLE_NAME --policy-arn arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess
+done
+
+echo "Creating ChangeManagerTemplateApproverRole..."
+aws iam create-role --role-name ChangeManagerTemplateApproverRole --assume-role-policy-document file://policies/MyAccountTrustPolicy.json
+TEMPLATE_APPROVER_POLICY_ARN=$(aws iam create-policy --policy-name ChangeManagerTemplateApproverRole --policy-document file://policies/TemplateApproverPolicy.json | jq -r '.Policy.Arn')
+aws iam attach-role-policy --role-name ChangeManagerTemplateApproverRole --policy-arn $TEMPLATE_APPROVER_POLICY_ARN
+aws iam attach-role-policy --role-name ChangeManagerTemplateApproverRole --policy-arn arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess
+
+echo "Creating SSM Service Linked Role..."
+aws iam create-service-linked-role --aws-service-name ssm.amazonaws.com || echo -e "SSM Service Linked Role already created \n\n"
+
+echo "Note: If you want to improve the security of your roles you can scope the following operations in the CreatePAIPolicy down to the specific PAA ARN(s) after creation:"
+echo "acm-pca:GetCertificateAuthorityCertificate, acm-pca:GetCertificate, acm-pca:IssueCertificate"

--- a/ssm-automation/createRoles.sh
+++ b/ssm-automation/createRoles.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 
-# Replace with your AWS account ID
-AWS_ACCOUNT="1234567890"
+set -euo pipefail
 
-# Replace with the number of approver roles you want to create
-NUMBER_OF_REQUEST_APPROVERS=2
+NUMBER_OF_REQUEST_APPROVERS=${1:-2}
+AWS_ACCOUNT=$(aws sts get-caller-identity | jq -r '.Account')
 
 echo "Creating CreatePAARole..."
 aws iam create-role --role-name CreatePAARole --assume-role-policy-document file://policies/SSMTrustPolicy.json

--- a/ssm-automation/policies/AccountTrustPolicy.json
+++ b/ssm-automation/policies/AccountTrustPolicy.json
@@ -1,0 +1,13 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::<AccountID>:root"
+            },
+            "Action": "sts:AssumeRole",
+            "Condition": {}
+        }
+    ]
+}

--- a/ssm-automation/policies/CreatePAAPolicy.json
+++ b/ssm-automation/policies/CreatePAAPolicy.json
@@ -1,0 +1,17 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "acm-pca:ImportCertificateAuthorityCertificate",
+                "acm-pca:IssueCertificate",
+                "acm-pca:CreateCertificateAuthority",
+                "acm-pca:GetCertificate",
+                "acm-pca:GetCertificateAuthorityCsr",
+                "acm-pca:DescribeCertificateAuthority"
+            ],
+            "Resource": "*"
+        }
+    ]
+}

--- a/ssm-automation/policies/CreatePAIPolicy.json
+++ b/ssm-automation/policies/CreatePAIPolicy.json
@@ -1,0 +1,24 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "acm-pca:ImportCertificateAuthorityCertificate",
+                "acm-pca:CreateCertificateAuthority",
+                "acm-pca:GetCertificateAuthorityCsr",
+                "acm-pca:DescribeCertificateAuthority"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "acm-pca:GetCertificateAuthorityCertificate",
+                "acm-pca:GetCertificate",
+                "acm-pca:IssueCertificate"
+            ],
+            "Resource": "*"
+        }
+    ]
+}

--- a/ssm-automation/policies/SSMTrustPolicy.json
+++ b/ssm-automation/policies/SSMTrustPolicy.json
@@ -1,0 +1,15 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Service": [
+                    "iam.amazonaws.com",
+                    "ssm.amazonaws.com"
+                ]
+            },
+            "Action": "sts:AssumeRole"
+        }
+    ]
+}

--- a/ssm-automation/policies/TemplateApproverPolicy.json
+++ b/ssm-automation/policies/TemplateApproverPolicy.json
@@ -1,0 +1,11 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": "ssm:UpdateDocumentMetadata",
+            "Resource": "*"
+        }
+    ]
+}


### PR DESCRIPTION
This change adds a more detailed description to the README of all roles and permissions required to complete the multi-party approvals. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
