### PR TITLE
Obtaining VendorId from PAA as opposed to relying on user's input (Ve…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules
 gradle/
 .vscode/
 .idea/
+!/lib/index.js
 
 # CDK asset staging directory
 .cdk.staging

--- a/README.md
+++ b/README.md
@@ -51,13 +51,12 @@ When deploying the application, you can configure it to support different use ca
 
    To alter an existing PAA for use with Matter, use the following options:
    ```
-   cdk deploy --parameters paaArn=<PAA_ARN>"
+   cdk deploy --parameters paaArn=<PAA_ARN>
    ```
 3. To generate PAIs in the same AWS Region as the PAA
 
    ```
-   cdk deploy --context generatePaiCnt=<NUM_PAI> --parameters vendorId=<VENDOR_ID> --parameters 
-   productIds=<PRODUCT_ID1,...> --parameters validityInDays=<PAI_VALIDITY> --parameters paaArn=<PAA_ARN> --parameters dacValidityInDays=<DAC_VALIDITY>
+   cdk deploy --context generatePaiCnt=<NUM_PAI> --parameters productIds=<PRODUCT_ID1,...> --parameters validityInDays=<PAI_VALIDITY> --parameters paaArn=<PAA_ARN> --parameters dacValidityInDays=<DAC_VALIDITY>
    ```
 4. To generate PAIs in a different AWS Region from the PAA
 
@@ -65,8 +64,7 @@ When deploying the application, you can configure it to support different use ca
    (see [AWS Cloud Development Kit documentation](https://docs.aws.amazon.com/cdk/v2/guide/cli.html#cli-environment)):
 
    ```
-   cdk deploy --context generatePaiCnt=<NUM_PAI> --parameters vendorId=<VENDOR_ID> --parameters 
-   productIds=<PRODUCT_ID1,...> --profile <YOUR_PROFILE_FOR_DIFFERENT_REGION> --parameters validityInDays=<PAI_VALIDITY> --parameters paaArn=<PAA_ARN> --parameters dacValidityInDays=<DAC_VALIDITY>
+   cdk deploy --context generatePaiCnt=<NUM_PAI> --parameters productIds=<PRODUCT_ID1,...> --profile <YOUR_PROFILE_FOR_DIFFERENT_REGION> --parameters validityInDays=<PAI_VALIDITY> --parameters paaArn=<PAA_ARN> --parameters dacValidityInDays=<DAC_VALIDITY>
    ```
 5. To add more PAIs to the existing infrastructure
 
@@ -74,8 +72,7 @@ When deploying the application, you can configure it to support different use ca
 
    You can view the difference between the new stack and what is already deployed by calling `cdk diff` with the necessary parameters. For example:
    ```
-   cdk diff --context generatePaiCnt=<NUM_PAI> --parameters vendorId=<VENDOR_ID> --parameters 
-   productIds=<PRODUCT_ID1,...> --parameters validityInDays=<PAI_VALIDITY> --parameters paaArn=<PAA_ARN>
+   cdk diff --context generatePaiCnt=<NUM_PAI> --parameters productIds=<PRODUCT_ID1,...> --parameters validityInDays=<PAI_VALIDITY> --parameters paaArn=<PAA_ARN>
    ```
 6. To generate DAC certificates for each individual device to be embedded into its copy of a firmware
 
@@ -99,7 +96,7 @@ When deploying the application, you can configure it to support different use ca
    ```
 
 ### Parameters
-1. `--parameters vendorId=<VID>` - The vendor ID to be assigned to the CA. Note that when creating PAIs this value should be the same as in the PAA. This must be a 4-digit hex value.
+1. `--parameters vendorId=<VID>` - The vendor ID to be assigned to the CA. This must be a 4-digit hex value.
 2. `--parameters productIds=<PID1>,<PID2>,...` - The productIds to be assigned to PAIs. Note that the number of PIDs provided should equal the `generatePaiCnt` parameter's value. These must be 4-digit hex values.
 3. `--parameters validityInDays=<n>` - The PAA/PAI certificate's validity in days.
 4. `--parameters dacValidityInDays=<n>` - The validity in days of the DACs that are issued by the Lambda. This value must be less than the PAI's `validityInDays` value.

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,54 @@
+const { ACMPCAClient, DescribeCertificateAuthorityCommand } = require("@aws-sdk/client-acm-pca");
+
+function is4DigitHexNumber(value) {
+    // The values SHALL be encoded in network byte order as exactly twice their specified maximum octet length, encoded as uppercase
+    // hexadecimal number format without any separators or prefix, and without omitting any leading zeroes.
+    return /^[0-9A-F]{4}$/.test(value);
+}
+
+exports.handler = async function(event, context) {
+    if (event.RequestType === "Delete") {
+        return {};
+    }
+
+    const userMsg = "should be 4-digit hexadecimal number in all capitals";
+
+    switch (event.ResourceProperties.command) {
+        case "getPaaVendorId":
+            const pcaClient = new ACMPCAClient({
+                region: event.ResourceProperties.paaRegion
+            });
+            const cmd = new DescribeCertificateAuthorityCommand({
+                CertificateAuthorityArn: event.ResourceProperties.paaArn
+            });
+            const response = await pcaClient.send(cmd);
+            const ca = response.CertificateAuthority;
+            const vidAttribute = ca.CertificateAuthorityConfiguration.Subject
+                .CustomAttributes.find(id => id.ObjectIdentifier === "1.3.6.1.4.1.37244.2.1");
+            if (vidAttribute === undefined) {
+                throw new Error('Provided PAA isn\'t VID-scoped (no Custom Attribute found in its Subject)');
+            }
+            const vid = vidAttribute.Value;
+            if (!is4DigitHexNumber(vid)) {
+                throw new Error('Invalid PAA with VID ' + event.ResourceProperties.vid + ', ' + userMsg);
+            }
+            return { Data: { Result: vid } };
+
+        case "validateVidPid":
+            if (event.ResourceProperties.vid !== undefined && !is4DigitHexNumber(event.ResourceProperties.vid)) {
+                throw new Error('Invalid VID ' + event.ResourceProperties.vid + ', ' + userMsg);
+            }
+            if (event.ResourceProperties.pids !== undefined && !event.ResourceProperties.pids.every((val) => is4DigitHexNumber(val))) {
+                throw new Error('Invalid PIDs [' + event.ResourceProperties.pids + '], each ' + userMsg);
+            }
+
+            return {
+                Data: {
+                    vid: event.ResourceProperties.vid,
+                    pids: event.ResourceProperties.pids
+                }
+            };
+    }
+
+    throw new Error('UNKNOWN COMMAND ' + event.ResourceProperties.command);
+};


### PR DESCRIPTION
Obtaining VendorId from PAA as opposed to relying on user's input (VendorId must coincide in PAA and PAI).

*Issue #, if available:*
#5 

*Description of changes:*
Obtaining VendorId from PAA as opposed to relying on user's input (VendorId must coincide in PAA and PAI).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
